### PR TITLE
Automate image building and pushing for Bevy main and latest

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -55,7 +55,9 @@ jobs:
         with:
           context: images
           file: images/Dockerfile
-          build-args: version=${{ matrix.version }} channel=${{ matrix.channel }}
+          build-args: |
+            version=${{ matrix.version }}
+            channel=${{ matrix.channel }}
           push: true
           cache-from: type=gha,scope=${{ matrix.version }}-${{ matrix.channel }}
           cache-to: type=gha,scope=${{ matrix.version }}-${{ matrix.channel }},mode=max

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          context: /images
-          file: /images/Dockerfile
+          context: images
+          file: images/Dockerfile
           build-args: version=${{ matrix.version }} channel=${{ matrix.channel }}
           push: true
           cache-from: type=gha,scope=${{ matrix.version }}-${{ matrix.channel }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   schedule:
   - cron: 0 0 * * *
+  push:
+    branches:
+      - "gh-workflow-image-building"
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         version:
           - main
+          - 0.13
         channel:
         - stable
         - nightly

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -16,6 +16,7 @@ jobs:
     name: Build ${{ matrix.version }} on ${{ matrix.channel }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         version:
           - main

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -62,6 +62,6 @@ jobs:
           push: true
           cache-from: type=gha,scope=${{ matrix.version }}-${{ matrix.channel }}
           cache-to: type=gha,scope=${{ matrix.version }}-${{ matrix.channel }},mode=max
-          tags: ${{ env.IMAGE_NAME }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -62,6 +62,6 @@ jobs:
           push: true
           cache-from: type=gha,scope=${{ matrix.version }}-${{ matrix.channel }}
           cache-to: type=gha,scope=${{ matrix.version }}-${{ matrix.channel }},mode=max
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ github.actor }}/${{ env.IMAGE_NAME }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -62,6 +62,6 @@ jobs:
           push: true
           cache-from: type=gha,scope=${{ matrix.version }}-${{ matrix.channel }}
           cache-to: type=gha,scope=${{ matrix.version }}-${{ matrix.channel }},mode=max
-          tags: ${{ github.actor }}/${{ env.IMAGE_NAME }}
+          tags: ${{ env.IMAGE_NAME }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,54 @@
+name: Build images
+
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: 0 0 * * *
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    name: Build ${{ matrix.version }} on ${{ matrix.channel }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version:
+          - main
+        channel:
+        - stable
+        - nightly
+    env:
+      IMAGE_NAME: ${{ github.repository }}-${{ matrix.version }}-${{ matrix.channel }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          build-args: version=${{ matrix.version }} channel=${{ matrix.channel }}
+          push: true
+          cache-from: type=gha,scope=${{ matrix.version }}-${{ matrix.channel }}
+          cache-to: type=gha,scope=${{ matrix.version }}-${{ matrix.channel }},mode=max
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -48,7 +48,8 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          context: .
+          context: /images
+          file: /images/Dockerfile
           build-args: version=${{ matrix.version }} channel=${{ matrix.channel }}
           push: true
           cache-from: type=gha,scope=${{ matrix.version }}-${{ matrix.channel }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch:
   schedule:
   - cron: 0 0 * * *
-  push:
-    branches:
-      - "gh-workflow-image-building"
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -32,6 +32,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: image=moby/buildkit:v0.11.6
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Completes the "building" part of #9 and the "automatic updating" part of #8.

GitHub actions builds and pushes images every night for the Bevy main branch and latest release.