### PR TITLE
Improve caching speed

### DIFF
--- a/bevy_compile_api/Cargo.toml
+++ b/bevy_compile_api/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-async-compression = { version = "0.4.8", features = ["gzip", "futures-io"] }
 async-std = { version = "1.12", features = ["attributes"] }
 chrono = "0.4"
 fastmurmur3 = "0.2"
 fastrand = "2.0"
 fern = { version = "0.6", features = ["date-based"] }
+flate2 = "1.0"
 log = "0.4"
 rust_minify = "0.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/bevy_compile_api/Cargo.toml
+++ b/bevy_compile_api/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+async-compression = { version = "0.4.8", features = ["gzip", "futures-io"] }
 async-std = { version = "1.12", features = ["attributes"] }
 chrono = "0.4"
 fastmurmur3 = "0.2"
@@ -13,7 +14,6 @@ log = "0.4"
 rust_minify = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 tide = { version = "0.16", default-features = false, features = ["async-h1", "h1-server"] }
-tide-compress = { version = "0.11", default-features = false, features = ["gzip"] }
 tide-rustls = "0.3"
 
 [features]

--- a/bevy_compile_api/src/main.rs
+++ b/bevy_compile_api/src/main.rs
@@ -35,7 +35,6 @@ async fn main() -> Result<(), std::io::Error> {
     app.with(disallowed_words_middleware);
     app.with(hash_middleware);
     app.with(cache::cache_middleware);
-    app.with(tide_compress::CompressMiddleware::new());
     app.with(After(|response: Response| async move {
         let Id(id) = response.ext().unwrap();
         compile::cleanup(*id).await;


### PR DESCRIPTION
For some reason take the bytes from the response was taking half a second in release mode and 4 seconds in debug mode. To get around this we can replace the Lengths ext with the cache entry itself and compress the body ourselves.