### PR TITLE
Compile Api Metrics

### DIFF
--- a/compile_api/Cargo.toml
+++ b/compile_api/Cargo.toml
@@ -10,7 +10,9 @@ fastmurmur3 = "0.2"
 fastrand = "2.0"
 fern = { version = "0.6", features = ["date-based"] }
 flate2 = "1.0"
+lazy_static = "1.4.0"
 log = "0.4"
+prometheus = "0.13"
 rust_minify = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 tide = { version = "0.16", default-features = false, features = ["async-h1", "h1-server"] }

--- a/compile_api/metrics_testing/README.md
+++ b/compile_api/metrics_testing/README.md
@@ -1,0 +1,15 @@
+## Metrics Testing
+
+The [docker-compose.yml](./docker-compose.yml) contains a Prometheus service for scaping the metrics endpoint and a Grafana service for visualizing the data. You can run them both with `docker compose up`.
+
+### Prometheus
+
+Once running, Prometheus should start scraping the metrics as defined in [prometheus.yml](./prometheus.yml). You can make sure it's working by going to http://localhost:9090/targets. The target's state should be `up`.
+
+### Grafana
+
+After confirming that Prometheus is functioning you can head over to Grafana at http://localhost:3000 and sign it with the default username and password, "admin".
+
+The first step ia to add the Prometheus instance as a data source. Go to http://localhost:3000/connections/datasources/new and select Prometheus. On the configuration page, under connection, set the url to `http://localhost:9090`. At the bottom of the page click "Save & test" and it should give a successful response.
+
+To add the example dashboard you can go to http://localhost:3000/dashboard/import and paste the contents of [example-dashboard.json](./example-dashboard.json) in to the "Import via dashboard JSON model" text area. After clicking load it will ask which Prometheus data source to use, select the one we added prior, it should be the only option. Import it and everything should be fully set up.

--- a/compile_api/metrics_testing/docker-compose.yml
+++ b/compile_api/metrics_testing/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    network_mode: host
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    restart: unless-stopped
+    volumes:
+      - .:/etc/prometheus
+      - prom_data:/prometheus
+
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    network_mode: host
+    restart: unless-stopped
+    ports:
+     - '3000:3000'
+    volumes:
+      - grafana_data:/var/lib/grafana
+
+volumes:
+    prom_data:
+    grafana_data:

--- a/compile_api/metrics_testing/example-dashboard.json
+++ b/compile_api/metrics_testing/example-dashboard.json
@@ -187,6 +187,19 @@
           "legendFormat": "IP Locked",
           "range": true,
           "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(internal_error_total[5m]) * 300",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Internal Server Error",
+          "range": true,
+          "refId": "E"
         }
       ],
       "title": "Requets every 5 minutes",
@@ -363,20 +376,20 @@
       "type": "timeseries"
     }
   ],
-  "refresh": "",
+  "refresh": "5s",
   "schemaVersion": 39,
   "tags": [],
   "templating": {
     "list": []
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
   "title": "Compile Api",
   "uid": "edjkwo06oa3ggf",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/compile_api/metrics_testing/example-dashboard.json
+++ b/compile_api/metrics_testing/example-dashboard.json
@@ -1,0 +1,382 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.4.2"
+    },
+    {
+      "type": "panel",
+      "id": "histogram",
+      "name": "Histogram",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(compile_requests_total[5m]) * 300",
+          "instant": false,
+          "legendFormat": "Requests",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(cahe_hit_total[5m]) * 300",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Cache Hits",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(rate_limited_requests_total[5m]) * 300",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Rate Limited",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(ip_locked_requests_total[5m]) * 300",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "IP Locked",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Requets every 5 minutes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 11
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "pluginVersion": "10.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "rate(compile_request_duration_seconds_bucket{}[$__rate_interval])",
+          "format": "heatmap",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Compile Duration",
+      "type": "histogram"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 11
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(compile_request_duration_seconds_sum[1h]) / rate(compile_request_duration_seconds_count[1h])",
+          "instant": false,
+          "legendFormat": "Avgerage Compile Time",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Average Compile Time per hour",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Compile Api",
+  "uid": "edjkwo06oa3ggf",
+  "version": 1,
+  "weekStart": ""
+}

--- a/compile_api/metrics_testing/example-dashboard.json
+++ b/compile_api/metrics_testing/example-dashboard.json
@@ -155,7 +155,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(cahe_hit_total[5m]) * 300",
+          "expr": "rate(cache_hit_total[5m]) * 300",
           "hide": false,
           "instant": false,
           "legendFormat": "Cache Hits",

--- a/compile_api/metrics_testing/prometheus.yml
+++ b/compile_api/metrics_testing/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: 'compile_api'
+    scheme: https
+    static_configs:
+      - targets: ['localhost:53740']
+    tls_config:
+      insecure_skip_verify: true

--- a/compile_api/src/cache.rs
+++ b/compile_api/src/cache.rs
@@ -1,4 +1,4 @@
-use crate::{Id, MinifiedHash};
+use crate::{metrics::CACHE_HIT_COUNTER, Id, MinifiedHash};
 use async_std::{fs, stream::StreamExt};
 use log::{error, info, warn};
 use std::{future::Future, pin::Pin};
@@ -40,6 +40,7 @@ pub fn cache_middleware<'a>(
         if !cache_bypass {
             if let Ok(Some(cache)) = get_cache(hash).await {
                 info!("{id}: Responded with cache");
+                CACHE_HIT_COUNTER.inc();
                 return Ok(Response::builder(StatusCode::Ok)
                     .body(Body::from_bytes(cache.body))
                     .header("wasm-content-length", cache.wasm_length.to_string())

--- a/compile_api/src/main.rs
+++ b/compile_api/src/main.rs
@@ -10,6 +10,7 @@ mod compile;
 mod config;
 mod ip_lock;
 mod logging;
+mod metrics;
 mod rate_limiting;
 
 #[async_std::main]
@@ -20,38 +21,44 @@ async fn main() -> Result<(), std::io::Error> {
 
     app.with(
         tide::security::CorsMiddleware::new()
-            .allow_methods(HeaderValue::from_str("POST").unwrap())
+            .allow_methods(HeaderValue::from_str("GET,POST").unwrap())
             .allow_headers(HeaderValue::from_str("content-type").unwrap())
             .expose_headers(
                 // These headers need to be accessible by the frontend to decode the response
                 HeaderValue::from_str("wasm-content-length, js-content-length").unwrap(),
             ),
     );
-    app.with(peer_addr_middleware);
-    app.with(rate_limiting::RateLimitMiddleware::new());
-    app.with(ip_lock::IpLockMiddleware::new());
-    app.with(id_middleware);
-    app.with(logging::logging_middleware);
-    app.with(input_middleware);
-    app.with(disallowed_words_middleware);
-    app.with(hash_middleware);
-    app.with(cache::cache_middleware);
-    app.with(After(|response: Response| async move {
-        let Id(id) = response.ext().unwrap();
-        compile::cleanup(*id).await;
-        Ok(response)
-    }));
-    app.with(After(|mut response: Response| async {
-        let Id(id) = response.ext().unwrap();
-        if let Some(err) = response.error() {
-            error!("{id}: Failed with error: {err:?}");
-            response.set_body(Body::from_json(&Error::Internal)?);
-        }
-        Ok(response)
-    }));
-    app.with(transfer_id_middleware);
 
-    app.at("/compile").post(compile::compile);
+    app.at("/compile")
+        .with(peer_addr_middleware)
+        .with(metrics::metrics_counter_middleware)
+        .with(rate_limiting::RateLimitMiddleware::new())
+        .with(ip_lock::IpLockMiddleware::new())
+        .with(id_middleware)
+        .with(logging::logging_middleware)
+        .with(input_middleware)
+        .with(disallowed_words_middleware)
+        .with(hash_middleware)
+        .with(cache::cache_middleware)
+        .with(After(|response: Response| async move {
+            let Id(id) = response.ext().unwrap();
+            compile::cleanup(*id).await;
+            Ok(response)
+        }))
+        .with(After(|mut response: Response| async {
+            let Id(id) = response.ext().unwrap();
+            if let Some(err) = response.error() {
+                error!("{id}: Failed with error: {err:?}");
+                response.set_body(Body::from_json(&Error::Internal)?);
+            }
+            Ok(response)
+        }))
+        .with(transfer_id_middleware)
+        .with(metrics::metrics_duration_middleware)
+        .post(compile::compile);
+
+    app.at("/metrics").get(metrics::metrics_handler);
+
     app.listen(
         TlsListener::build()
             .addrs("0.0.0.0:53740")

--- a/compile_api/src/main.rs
+++ b/compile_api/src/main.rs
@@ -1,5 +1,6 @@
 use config::{Channel, Version};
 use log::error;
+use metrics::INTERNAL_ERROR_COUNTER;
 use serde::{Deserialize, Serialize};
 use std::{future::Future, net::IpAddr, pin::Pin, str::FromStr};
 use tide::{http::headers::HeaderValue, utils::After, Body, Next, Request, Response, StatusCode};
@@ -49,6 +50,7 @@ async fn main() -> Result<(), std::io::Error> {
             let Id(id) = response.ext().unwrap();
             if let Some(err) = response.error() {
                 error!("{id}: Failed with error: {err:?}");
+                INTERNAL_ERROR_COUNTER.inc();
                 response.set_body(Body::from_json(&Error::Internal)?);
             }
             Ok(response)

--- a/compile_api/src/metrics.rs
+++ b/compile_api/src/metrics.rs
@@ -1,0 +1,66 @@
+use prometheus::{opts, register_counter, register_histogram, Counter, Histogram, TextEncoder};
+use std::{future::Future, pin::Pin};
+use tide::{Next, Request, Response, StatusCode};
+
+lazy_static::lazy_static! {
+    static ref REQUEST_COUNTER: Counter = register_counter!(opts!(
+        "compile_requests_total",
+        "Number of HTTP requests made.",
+    )).unwrap();
+
+    static ref REQUEST_DURATION_HISTOGRAM: Histogram = register_histogram!(
+        "compile_request_duration_seconds",
+        "The compile request latencies in seconds.",
+        vec![2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0],
+    )
+    .unwrap();
+
+    pub static ref CACHE_HIT_COUNTER: Counter = register_counter!(opts!(
+        "cahe_hit_total",
+        "Number of HTTP requests that served by a cache.",
+    )).unwrap();
+
+    pub static ref RATE_LIMIT_COUNTER: Counter = register_counter!(opts!(
+        "rate_limited_requests_total",
+        "Number of HTTP requests that have been rate limited.",
+    )).unwrap();
+
+    pub static ref IP_LOCK_COUNTER: Counter = register_counter!(opts!(
+        "ip_locked_requests_total",
+        "Number of HTTP requests that have been ip locked.",
+    )).unwrap();
+}
+
+pub fn metrics_counter_middleware<'a>(
+    request: Request<()>,
+    next: Next<'a, ()>,
+) -> Pin<Box<dyn Future<Output = tide::Result> + Send + 'a>> {
+    Box::pin(async {
+        REQUEST_COUNTER.inc();
+        Ok(next.run(request).await)
+    })
+}
+
+pub fn metrics_duration_middleware<'a>(
+    request: Request<()>,
+    next: Next<'a, ()>,
+) -> Pin<Box<dyn Future<Output = tide::Result> + Send + 'a>> {
+    Box::pin(async {
+        let timer = REQUEST_DURATION_HISTOGRAM.start_timer();
+        let response = next.run(request).await;
+        timer.observe_duration();
+        Ok(response)
+    })
+}
+
+pub async fn metrics_handler(_req: Request<()>) -> tide::Result {
+    let encoder = TextEncoder::new();
+    let metric_families = prometheus::gather();
+    let mut buffer = String::new();
+    encoder.encode_utf8(&metric_families, &mut buffer).unwrap();
+
+    Ok(Response::builder(StatusCode::Ok)
+        .body(buffer)
+        .content_type(tide::http::mime::PLAIN)
+        .build())
+}

--- a/compile_api/src/metrics.rs
+++ b/compile_api/src/metrics.rs
@@ -16,7 +16,7 @@ lazy_static::lazy_static! {
     .unwrap();
 
     pub static ref CACHE_HIT_COUNTER: Counter = register_counter!(opts!(
-        "cahe_hit_total",
+        "cache_hit_total",
         "Number of HTTP requests that served by a cache.",
     )).unwrap();
 

--- a/compile_api/src/metrics.rs
+++ b/compile_api/src/metrics.rs
@@ -48,7 +48,11 @@ pub fn metrics_duration_middleware<'a>(
     Box::pin(async {
         let timer = REQUEST_DURATION_HISTOGRAM.start_timer();
         let response = next.run(request).await;
-        timer.observe_duration();
+        if response.status() == StatusCode::Ok {
+            timer.observe_duration();
+        } else {
+            timer.stop_and_discard();
+        }
         Ok(response)
     })
 }

--- a/compile_api/src/metrics.rs
+++ b/compile_api/src/metrics.rs
@@ -29,6 +29,11 @@ lazy_static::lazy_static! {
         "ip_locked_requests_total",
         "Number of HTTP requests that have been ip locked.",
     )).unwrap();
+
+    pub static ref INTERNAL_ERROR_COUNTER: Counter = register_counter!(opts!(
+        "internal_error_total",
+        "Number of HTTP requests that resulted in an internal server error.",
+    )).unwrap();
 }
 
 pub fn metrics_counter_middleware<'a>(

--- a/compile_api/src/rate_limiting.rs
+++ b/compile_api/src/rate_limiting.rs
@@ -1,4 +1,4 @@
-use crate::{Error, PeerAddr};
+use crate::{metrics::RATE_LIMIT_COUNTER, Error, PeerAddr};
 use async_std::sync::Mutex;
 use std::{
     collections::HashMap,
@@ -34,6 +34,7 @@ impl<State: Clone + Send + Sync + 'static> Middleware<State> for RateLimitMiddle
         let mut limits = self.limits.lock().await;
         if let Some(rate_limit) = limits.get(&peer_ip) {
             if rate_limit.start.elapsed() < rate_limit.duration {
+                RATE_LIMIT_COUNTER.inc();
                 let time_left = (rate_limit.duration - rate_limit.start.elapsed())
                     .as_secs_f32()
                     .ceil();


### PR DESCRIPTION
Closes #27 

Adds a /metrics endpoint to the compile_api server which serves a Prometheus compatible response. The following metrics are currently recorded.

- Request count
- Successful request duration
- Cache hit counter
- Rate limit counter
- Ip lock counter