### PR TITLE
Temporarily disable Bevy versions v0.10 -> v0.12

### DIFF
--- a/www/src/routes/playground/Settings.svelte
+++ b/www/src/routes/playground/Settings.svelte
@@ -45,7 +45,12 @@
                     <Select.Content>
                         {#each VERSIONS as version}
                             {@const disabled = ["0.10", "0.11", "0.12"].includes(version)}
-                            <Select.Item class="capitalize" value={version} label={version} {disabled}>
+                            <Select.Item
+                                class="capitalize"
+                                value={version}
+                                label={version}
+                                {disabled}
+                            >
                                 {version}
                             </Select.Item>
                         {/each}

--- a/www/src/routes/playground/Settings.svelte
+++ b/www/src/routes/playground/Settings.svelte
@@ -44,7 +44,8 @@
                     </Select.Trigger>
                     <Select.Content>
                         {#each VERSIONS as version}
-                            <Select.Item class="capitalize" value={version} label={version}>
+                            {@const disabled = ["0.10", "0.11", "0.12"].includes(version)}
+                            <Select.Item class="capitalize" value={version} label={version} {disabled}>
                                 {version}
                             </Select.Item>
                         {/each}


### PR DESCRIPTION
While I am messing with the server and have to keep repulling images, I'd like to keep the number of images to a minimum.