### PR TITLE
fix: Prune podman images after pulling

### DIFF
--- a/compile_server_os/configuration.nix
+++ b/compile_server_os/configuration.nix
@@ -104,6 +104,7 @@
       ${pkgs.podman}/bin/podman pull ghcr.io/liamgallagher737/learnbevy-main-stable:main
       ${pkgs.podman}/bin/podman pull ghcr.io/liamgallagher737/learnbevy-0.14-nightly:main
       ${pkgs.podman}/bin/podman pull ghcr.io/liamgallagher737/learnbevy-0.14-stable:main
+      ${pkgs.podman}/bin/podman image prune -f
     '';
     wantedBy = [ "default.target" ];
     path = [


### PR DESCRIPTION
Without this the server will run out of storage from all the dangling images