### PR TITLE
Cache fetches to Crates.io API in `check_crate_updates` tool

### DIFF
--- a/tools/check_crate_updates/Cargo.toml
+++ b/tools/check_crate_updates/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.86"
+cached = "0.52.0"
 semver = "1.0.23"
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.120"


### PR DESCRIPTION
To avoid spamming crates.io too much and also increase speed of execution.