### PR TITLE
Add burst to nginx config

### DIFF
--- a/compile_server_os/configuration.nix
+++ b/compile_server_os/configuration.nix
@@ -66,7 +66,7 @@
         # set headers so it can be trusted
         extraConfig = ''
           proxy_set_header X-Real-IP $remote_addr;
-          limit_req zone=ip;
+          limit_req zone=ip burst=4 nodelay;
           limit_req_status 429;
         '';
       };


### PR DESCRIPTION
The rate limit was blocking real requests due to the POST happening less than 14th a second after the OPTIONS.