### PR TITLE
Never pull images (compile_api)

### DIFF
--- a/compile_api/src/compile.rs
+++ b/compile_api/src/compile.rs
@@ -35,6 +35,8 @@ pub async fn compile(request: Request<()>) -> Result<Response, tide::Error> {
             "-v",
             &format!("{}:/playground/src/:z", dir.display()),
             "--quiet",
+            "--pull",
+            "never",
             &config::image_for_config(*version, *channel),
         ])
         .output()


### PR DESCRIPTION
I'd rather it error if the image can't be found locally