### PR TITLE
Remove `leafwing-input-manager` from 0.14

### DIFF
--- a/images/manifests/0.14.Cargo.toml
+++ b/images/manifests/0.14.Cargo.toml
@@ -38,8 +38,8 @@ avian3d = "=0.1.1"
 bevy_mod_picking = "=0.20.1"
 bevy_prototype_lyon = "=0.12.0"
 bevy_kira_audio = "=0.20.0"
-leafwing-input-manager = "=0.14.0"
 bevy_light_2d = "=0.3.0"
+#leafwing-input-manager = "=0.14.0"
 #bevy_dev = { version = "0.3.0", default-features = false }
 
 wasm-bindgen = "0.2"


### PR DESCRIPTION
Can be added back once Leafwing-Studios/leafwing-input-manager#590 has made it in to a release.