### PR TITLE
Use local path for `compile_server_os` `learnbevy` input

### DIFF
--- a/compile_server_os/flake.nix
+++ b/compile_server_os/flake.nix
@@ -3,13 +3,7 @@
   inputs.disko.url = "github:nix-community/disko";
   inputs.disko.inputs.nixpkgs.follows = "nixpkgs";
 
-  inputs.learnbevy = {
-      type = "github";
-      owner = "LiamGallagher737";
-      repo = "learnbevy";
-      ref = "main";
-      dir = "compile_api";
-  };
+  inputs.learnbevy.url = "path:./../compile_api";
 
   outputs = inputs@{ self, nixpkgs, disko, ... }:
     {


### PR DESCRIPTION
This means changes to the `compile_api` will be automatically deployed without updating the `compile_server_os`'s `flake.lock`.